### PR TITLE
Adaptacion del triggertemplate y roles para deploy

### DIFF
--- a/triggers/tekton-greeter-triggerbinding.yaml
+++ b/triggers/tekton-greeter-triggerbinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
 metadata:
-  name: tekton-greeter-triggerbinding
+  name: greeter-triggerbinding
 spec:
   params:
   - name: git-repo-url

--- a/triggers/tekton-greeter-triggertemplate.yaml
+++ b/triggers/tekton-greeter-triggertemplate.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
-  name: tekton-greeter-triggertemplate
+  name: greeter-triggertemplate
 spec:
   params:
     - name: git-revision
@@ -15,17 +15,31 @@ spec:
       kind: PipelineRun
       metadata:
         labels:
-          tekton.dev/pipeline: tekton-greeter-pipeline-hub
-        name: tekton-greeter-pipeline-webhook-$(uid)
+          tekton.dev/pipeline: greeter-pipeline-hub
+        name: greeter-pipeline-webhook-$(uid)
       spec:
         params:
           - name: GIT_REPO
             value: $(tt.params.git-repo-url)
           - name: GIT_REF
             value: $(tt.params.git-revision)
+          - name: DESTINATION_IMAGE
+            value: 'quay.io/lmtbelmonte01/tekton-greeter-pipeline:latest'  
+          - name: IMAGE_DOCKERFILE
+            value: quarkus/Dockerfile
+          - name: CONTEXT_DIR
+            value: quarkus
+          - name: IMAGE_CONTEXT_DIR
+            value: quarkus
+          - name: SCRIPT
+            value: >
+              kubectl create deploy tekton-greeter --image=quay.io/lmtbelmonte01/tekton-greeter-pipeline:latest  
         serviceAccountName: tekton-triggers-sa
         pipelineRef:
-          name: tekton-greeter-pipeline-hub
+          name: greeter-pipeline-hub
+        podTemplate:
+          securityContext:
+            fsGroup: 65532  
         workspaces:
         - name: app-source
           persistentVolumeClaim:

--- a/triggers/tekton-role-binding.yaml
+++ b/triggers/tekton-role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: trigger-task-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers-sa
+roleRef:
+  kind: Role
+  name: task-role
+  apiGroup: rbac.authorization.k8s.io

--- a/triggers/tekton-trigger-eventlistener.yaml
+++ b/triggers/tekton-trigger-eventlistener.yaml
@@ -1,11 +1,11 @@
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: EventListener
 metadata:
-  name: tekton-greeter-eventlistener
+  name: greeter-eventlistener
 spec:
   serviceAccountName: tekton-triggers-sa
   triggers:
   - bindings:
-    - ref: tekton-greeter-triggerbinding
+    - ref: greeter-triggerbinding
     template:
-      ref: tekton-greeter-triggertemplate
+      ref: greeter-triggertemplate

--- a/triggers/tekton-triggers-sa.yaml
+++ b/triggers/tekton-triggers-sa.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tekton-triggers-sa
+secrets:
+  - name: container-registry-secret


### PR DESCRIPTION
Cuando se usa el webhook para ejecutar el pipeline , hay que dejar el trigger template que lleva el pipeline-run/ task-run igual que el del deploy. Igual que el service account que tiene que tener permisos Tambien para desplegar en k8s 